### PR TITLE
Allow resize packets to use any EntityLivingBase, rather than just EntityPlayers.

### DIFF
--- a/src/main/java/com/camellias/resizer/network/packets/PacketAlteredSize.java
+++ b/src/main/java/com/camellias/resizer/network/packets/PacketAlteredSize.java
@@ -5,6 +5,7 @@ import com.camellias.resizer.Main;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.potion.PotionEffect;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
@@ -47,7 +48,7 @@ public class PacketAlteredSize extends PacketOnResize
 		@Override
 		public IMessage onMessage(PacketAlteredSize message, MessageContext ctx)
 		{
-			Main.proxy.getThreadListener(ctx).addScheduledTask(() ->
+			FMLCommonHandler.instance().getWorldThread(ctx.netHandler).addScheduledTask(() ->
 			{
 				EntityLivingBase entity = message.removePotionEffect(ctx, !message.isGrowth, message.isGrowth);
 				if (entity != null)

--- a/src/main/java/com/camellias/resizer/network/packets/PacketAlteredSize.java
+++ b/src/main/java/com/camellias/resizer/network/packets/PacketAlteredSize.java
@@ -3,7 +3,7 @@ package com.camellias.resizer.network.packets;
 import com.camellias.resizer.Main;
 
 import io.netty.buffer.ByteBuf;
-import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.potion.PotionEffect;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
@@ -16,9 +16,9 @@ public class PacketAlteredSize extends PacketOnResize
 	
 	public PacketAlteredSize() {}
 	
-	public PacketAlteredSize(EntityPlayer player, boolean isGrowth, int duration, int amplifier, boolean shouldSpawnParticles)
+	public PacketAlteredSize(EntityLivingBase entity, boolean isGrowth, int duration, int amplifier, boolean shouldSpawnParticles)
 	{
-		super(player, shouldSpawnParticles);
+		super(entity, shouldSpawnParticles);
 		this.isGrowth = isGrowth;
 		this.duration = duration;
 		this.amplifier = amplifier;
@@ -49,10 +49,10 @@ public class PacketAlteredSize extends PacketOnResize
 		{
 			Main.proxy.getThreadListener(ctx).addScheduledTask(() ->
 			{
-				EntityPlayer player = message.removePotionEffect(ctx, !message.isGrowth, message.isGrowth);
-				if (player != null)
+				EntityLivingBase entity = message.removePotionEffect(ctx, !message.isGrowth, message.isGrowth);
+				if (entity != null)
 				{
-					player.addPotionEffect(new PotionEffect(message.isGrowth ? Main.GROWTH : Main.SHRINKING, message.duration, message.amplifier));
+					entity.addPotionEffect(new PotionEffect(message.isGrowth ? Main.GROWTH : Main.SHRINKING, message.duration, message.amplifier));
 				}
 			});
 			

--- a/src/main/java/com/camellias/resizer/network/packets/PacketNormalSize.java
+++ b/src/main/java/com/camellias/resizer/network/packets/PacketNormalSize.java
@@ -1,9 +1,8 @@
 package com.camellias.resizer.network.packets;
 
-import com.camellias.resizer.Main;
-
 import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
@@ -34,7 +33,7 @@ public class PacketNormalSize extends PacketOnResize
 		@Override
 		public IMessage onMessage(PacketNormalSize message, MessageContext ctx)
 		{
-			Main.proxy.getThreadListener(ctx).addScheduledTask(() -> message.removePotionEffect(ctx, true, true));
+			FMLCommonHandler.instance().getWorldThread(ctx.netHandler).addScheduledTask(() -> message.removePotionEffect(ctx, true, true));
 			return null;
 		}
 	}

--- a/src/main/java/com/camellias/resizer/network/packets/PacketNormalSize.java
+++ b/src/main/java/com/camellias/resizer/network/packets/PacketNormalSize.java
@@ -3,7 +3,7 @@ package com.camellias.resizer.network.packets;
 import com.camellias.resizer.Main;
 
 import io.netty.buffer.ByteBuf;
-import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
@@ -12,9 +12,9 @@ public class PacketNormalSize extends PacketOnResize
 {
 	public PacketNormalSize() {}
 	
-	public PacketNormalSize(EntityPlayer player)
+	public PacketNormalSize(EntityLivingBase entity)
 	{
-		super(player, true);
+		super(entity, true);
 	}
 	
 	@Override

--- a/src/main/java/com/camellias/resizer/network/packets/PacketSpawnParticles.java
+++ b/src/main/java/com/camellias/resizer/network/packets/PacketSpawnParticles.java
@@ -3,7 +3,7 @@ package com.camellias.resizer.network.packets;
 import com.camellias.resizer.Main;
 
 import io.netty.buffer.ByteBuf;
-import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
@@ -12,9 +12,9 @@ public class PacketSpawnParticles extends PacketOnResize
 {
 	public PacketSpawnParticles() {}
 	
-	public PacketSpawnParticles(EntityPlayer player)
+	public PacketSpawnParticles(EntityLivingBase entity)
 	{
-		super(player, true);
+		super(entity, true);
 	}
 	
 	@Override

--- a/src/main/java/com/camellias/resizer/network/packets/PacketSpawnParticles.java
+++ b/src/main/java/com/camellias/resizer/network/packets/PacketSpawnParticles.java
@@ -1,9 +1,8 @@
 package com.camellias.resizer.network.packets;
 
-import com.camellias.resizer.Main;
-
 import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
@@ -34,7 +33,7 @@ public class PacketSpawnParticles extends PacketOnResize
 		@Override
 		public IMessage onMessage(PacketSpawnParticles message, MessageContext ctx)
 		{
-			Main.proxy.getThreadListener(ctx).addScheduledTask(() -> message.removePotionEffect(ctx, false, false));
+			FMLCommonHandler.instance().getWorldThread(ctx.netHandler).addScheduledTask(() -> message.removePotionEffect(ctx, false, false));
 			return null;
 		}
 	}

--- a/src/main/java/com/camellias/resizer/proxy/ClientProxy.java
+++ b/src/main/java/com/camellias/resizer/proxy/ClientProxy.java
@@ -8,7 +8,6 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
-import net.minecraft.util.IThreadListener;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 
@@ -27,18 +26,5 @@ public class ClientProxy extends CommonProxy
 		EntityPlayer player = context.side.isClient() ? Minecraft.getMinecraft().player : context.getServerHandler().player;
 		Entity entity = player.world.getEntityByID(entityID);
 		return entity instanceof EntityLivingBase ? (EntityLivingBase) entity : null;
-	}
-	
-	@Override
-	public IThreadListener getThreadListener(final MessageContext context)
-	{
-		if(context.side.isClient())
-		{
-			return Minecraft.getMinecraft();
-		}
-		else
-		{
-			return context.getServerHandler().player.server;
-		}
 	}
 }

--- a/src/main/java/com/camellias/resizer/proxy/ClientProxy.java
+++ b/src/main/java/com/camellias/resizer/proxy/ClientProxy.java
@@ -1,7 +1,11 @@
 package com.camellias.resizer.proxy;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.util.IThreadListener;
@@ -17,16 +21,12 @@ public class ClientProxy extends CommonProxy
 	}
 	
 	@Override
-	public EntityPlayer getPlayer(final MessageContext context)
+	@Nullable
+	public EntityLivingBase getEntityLivingBase(MessageContext context, int entityID)
 	{
-		if(context.side.isClient())
-		{
-			return Minecraft.getMinecraft().player;
-		}
-		else
-		{
-			return context.getServerHandler().player;
-		}
+		EntityPlayer player = context.side.isClient() ? Minecraft.getMinecraft().player : context.getServerHandler().player;
+		Entity entity = player.world.getEntityByID(entityID);
+		return entity instanceof EntityLivingBase ? (EntityLivingBase) entity : null;
 	}
 	
 	@Override

--- a/src/main/java/com/camellias/resizer/proxy/CommonProxy.java
+++ b/src/main/java/com/camellias/resizer/proxy/CommonProxy.java
@@ -5,7 +5,6 @@ import javax.annotation.Nullable;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.Item;
-import net.minecraft.util.IThreadListener;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 
 public class CommonProxy 
@@ -24,18 +23,6 @@ public class CommonProxy
 			return entity instanceof EntityLivingBase ? (EntityLivingBase) entity : null;
 		}
 		throw new WrongSideException("Tried to get the player from a client-side MessageContext on the dedicated server");
-	}
-	
-	public IThreadListener getThreadListener(final MessageContext context)
-	{
-		if(context.side.isServer())
-		{
-			return context.getServerHandler().player.server;
-		}
-		else
-		{
-			throw new WrongSideException("Tried to get the IThreadListener from a client-side MessageContext on the dedicated server");
-		}
 	}
 	
 	class WrongSideException extends RuntimeException

--- a/src/main/java/com/camellias/resizer/proxy/CommonProxy.java
+++ b/src/main/java/com/camellias/resizer/proxy/CommonProxy.java
@@ -1,6 +1,9 @@
 package com.camellias.resizer.proxy;
 
-import net.minecraft.entity.player.EntityPlayer;
+import javax.annotation.Nullable;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.Item;
 import net.minecraft.util.IThreadListener;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
@@ -12,16 +15,15 @@ public class CommonProxy
 		
 	}
 	
-	public EntityPlayer getPlayer(final MessageContext context)
+	@Nullable
+	public EntityLivingBase getEntityLivingBase(MessageContext context, int entityID)
 	{
 		if(context.side.isServer())
 		{
-			return context.getServerHandler().player;
-		} 
-		else
-		{
-			throw new WrongSideException("Tried to get the player from a client-side MessageContext on the dedicated server");
+			Entity entity = context.getServerHandler().player.world.getEntityByID(entityID);
+			return entity instanceof EntityLivingBase ? (EntityLivingBase) entity : null;
 		}
+		throw new WrongSideException("Tried to get the player from a client-side MessageContext on the dedicated server");
 	}
 	
 	public IThreadListener getThreadListener(final MessageContext context)


### PR DESCRIPTION
This PR also replaces proxy methods with FMLCommonHandler#getWorldThread for getting the main thread.