### PR TITLE
Stabilize implementation of general entity support for resize potions.

### DIFF
--- a/src/main/java/com/camellias/resizer/handlers/PotionHandler.java
+++ b/src/main/java/com/camellias/resizer/handlers/PotionHandler.java
@@ -220,10 +220,10 @@ public class PotionHandler
 			{
 				EntityPlayer player = (EntityPlayer) entity;
 				player.eyeHeight = entity.height * 0.85F;
+				entity.jumpMovementFactor *= 1.75F;
 			}
 			
 			entity.stepHeight = entity.height / 3F;
-			entity.jumpMovementFactor *= 1.75F;
 			entity.fallDistance = 0.0F;
 			
 			try

--- a/src/main/java/com/camellias/resizer/handlers/PotionHandler.java
+++ b/src/main/java/com/camellias/resizer/handlers/PotionHandler.java
@@ -173,7 +173,7 @@ public class PotionHandler
 		PotionEffect growth = entity.getActivePotionEffect(Main.GROWTH);
 		PotionEffect shrinking = entity.getActivePotionEffect(Main.SHRINKING);
 		
-		if(entity.isPotionActive(Main.GROWTH))
+		if(growth != null)
 		{
 			entity.height = 1.8F + (growth.getAmplifier() + 1F);
 			entity.width = entity.height * (1F / 3F);
@@ -209,7 +209,7 @@ public class PotionHandler
             		entity.posX + d0, aabb.minY + entity.height, entity.posZ + d0));
 		}
 		
-		if(entity.isPotionActive(Main.SHRINKING))
+		if(shrinking != null)
 		{
 			entity.height = 0.9F / (shrinking.getAmplifier() + 1);
 			entity.width = 0.35F;
@@ -269,7 +269,7 @@ public class PotionHandler
             		entity.posX + d0, aabb.minY + entity.height, entity.posZ + d0));
 		}
 		
-		if(entity.isPotionActive(Main.GROWTH) == false && entity.isPotionActive(Main.SHRINKING) == false)
+		if(growth == null && shrinking == null)
 		{
 			if(entity instanceof EntityPlayer)
 			{
@@ -286,7 +286,7 @@ public class PotionHandler
 		EntityLivingBase entity = event.getEntityLiving();
 		PotionEffect potion = entity.getActivePotionEffect(Main.SHRINKING);
 		
-		if(entity.isPotionActive(Main.SHRINKING))
+		if(potion != null)
 		{
 			if(potion.getAmplifier() == 0)
 			{

--- a/src/main/java/com/camellias/resizer/handlers/PotionHandler.java
+++ b/src/main/java/com/camellias/resizer/handlers/PotionHandler.java
@@ -150,7 +150,7 @@ public class PotionHandler
 		if (event.getPotionEffect().getPotion() == potionTarget)
 		{
 			Potion potionOld = potionTarget == Main.GROWTH ? Main.SHRINKING : Main.GROWTH;
-			event.setResult((event.getEntityLiving()).isPotionActive(potionOld) ? Event.Result.DENY : Event.Result.ALLOW);
+			event.setResult(event.getEntityLiving().isPotionActive(potionOld) ? Event.Result.DENY : Event.Result.ALLOW);
 		}
 	}
 	
@@ -178,7 +178,7 @@ public class PotionHandler
 			entity.height = 1.8F + (growth.getAmplifier() + 1F);
 			entity.width = entity.height * (1F / 3F);
 			AxisAlignedBB aabb = entity.getEntityBoundingBox();
-			double d0 = (double)entity.width / 2.0D;
+			double d0 = entity.width / 2.0D;
 			
 			if(entity instanceof EntityPlayer)
 			{
@@ -206,7 +206,7 @@ public class PotionHandler
 			}
             
 			entity.setEntityBoundingBox(new AxisAlignedBB(entity.posX - d0, aabb.minY, entity.posZ - d0, 
-            		entity.posX + d0, aabb.minY + (double)entity.height, entity.posZ + d0));
+            		entity.posX + d0, aabb.minY + entity.height, entity.posZ + d0));
 		}
 		
 		if(entity.isPotionActive(Main.SHRINKING))
@@ -214,7 +214,7 @@ public class PotionHandler
 			entity.height = 0.9F / (shrinking.getAmplifier() + 1);
 			entity.width = 0.35F;
 			AxisAlignedBB aabb = entity.getEntityBoundingBox();
-			double d0 = (double)entity.width / 2.0D;
+			double d0 = entity.width / 2.0D;
 			
 			if(entity instanceof EntityPlayer)
 			{
@@ -266,7 +266,7 @@ public class PotionHandler
 			}
 			
 			entity.setEntityBoundingBox(new AxisAlignedBB(entity.posX - d0, aabb.minY, entity.posZ - d0, 
-            		entity.posX + d0, aabb.minY + (double)entity.height, entity.posZ + d0));
+            		entity.posX + d0, aabb.minY + entity.height, entity.posZ + d0));
 		}
 		
 		if(entity.isPotionActive(Main.GROWTH) == false && entity.isPotionActive(Main.SHRINKING) == false)


### PR DESCRIPTION
In addition to some cleanup, this PR:
1. Ensures that packets are only attempted to be sent from the server.
2. Allows non-player entity step heights to be reset when their resize effects end.
3. Allows size-change particles to spawn properly for all entities.
4. Prevents server freezing by only multiplying EntityLivingBase#jumpMovementFactor each tick for players.